### PR TITLE
Branches pages

### DIFF
--- a/_branches/en/north-side-blue-line.md
+++ b/_branches/en/north-side-blue-line.md
@@ -10,7 +10,7 @@ To find ways to connect with the working class to build a chapter that is more r
 
 ## Get involved
 
-Committee members/contact info: nsblue@chicagodsa.org
+Committee members/contact info: [nsblue@chicagodsa.org](mailto:nsblue@chicagodsa.org)
 
 {% include comp-button.html text="Find an upcoming event" link="/events" %}
 

--- a/_branches/en/north-side-blue-line.md
+++ b/_branches/en/north-side-blue-line.md
@@ -1,0 +1,21 @@
+---
+lang-ref: north-side-blue-line
+title: North Side Blue Line Branch
+---
+
+## Mission
+To find ways to connect with the working class to build a chapter that is more representative of the multi-racial working class.
+- Northside Blue Line Mutual Aid Solidarity
+- Lori Doesn’t CARES
+
+## Get involved
+
+Committee members/contact info: nsblue@chicagodsa.org
+
+{% include comp-button.html text="Find an upcoming event" link="/events" %}
+
+## Geography
+
+The following zipcodes fall under the North Side Blue Line Branch:
+
+60068, 60714, 60053, 60077, 60631, 60646, 60712, 60656, 60706, 60630, 60625, 60634, 60641, 60618, 60639, 60647, 60651, 60622, 60642, 60661, 60607, 60612, 60624, 60644

--- a/_branches/en/north-side-red-line.md
+++ b/_branches/en/north-side-red-line.md
@@ -8,6 +8,6 @@ Create a democratic, welcoming space for Northside socialists to learn, organize
 
 ## Get involved
 
-Committee members/contact info:nsr-steering@chicagodsa.org
+Committee members/contact info: [nsr-steering@chicagodsa.org](mailto:nsr-steering@chicagodsa.org)
 
 {% include comp-button.html text="Find an upcoming event" link="/events" %}

--- a/_branches/en/north-side-red-line.md
+++ b/_branches/en/north-side-red-line.md
@@ -1,0 +1,13 @@
+---
+lang-ref: north-side-red-line
+title: North Side Red Line Branch
+---
+
+## Mission
+Create a democratic, welcoming space for Northside socialists to learn, organize and grow working class power. We want to be an avenue for social cohesion and escalated involvement in the organizing goals of CDSA. This branch covers some of the most traditionally progressive bases in Chicago, and it’s our task to push those bases toward socialism.
+
+## Get involved
+
+Committee members/contact info:nsr-steering@chicagodsa.org
+
+{% include comp-button.html text="Find an upcoming event" link="/events" %}

--- a/_branches/en/south-side.md
+++ b/_branches/en/south-side.md
@@ -1,0 +1,17 @@
+---
+lang-ref: south-side
+title: South Side Branch
+---
+
+## Mission
+There is no socialist movement if it is not a multi-racial movement. There is no socialist movement if it doesn’t speak to those most oppressed by the systems we find ourselves in. The south side of Chicago has always been the site of intense racist capitalist oppression in the city, as well as some of the most liberating historical working class movements. The south side branch of CDSA seeks to honor that tradition by building the socialist movement in the communities hardest hit by capitalism. We consider it a priority to build this movement among the Black and brown communities of the south side. 
+
+The branch operates along three primary fronts of class struggle: the community, the workplace, and the state. In the community, we aim to unite and protect ourselves as neighbors against the forces of gentrification, environmental racism, predatory development, and racist institutions, such as the police and ICE. In the workplace, we are pitted against the bosses, the corporations, and the administrations, united as workers wielding our mightiest power: our labor. In the state, we aim to elect class struggle candidates to fight for the working class and public institutions as champions in city hall, using elections as a means of connecting with our communities, expanding the expectations of the working class for what we deserve, and building the base of our socialist movement.
+
+As a member of South Side Mutual Aid Solidarity (MAS), we engage in programs to meet the material demands of our neighbors in need as a means of survival. These programs are overtly political, offering space for our class to organize itself and challenge the systems that govern us to utilize our collective wealth to meet these needs as is their responsibility. We embrace the pursuit and practice of abolition.
+
+## Get involved
+
+Email us at southside@chicagodsa.org, or message our [Facebook page](https://www.facebook.com/Chicagodsa)
+
+{% include comp-button.html text="Find an upcoming event" link="/events" %}

--- a/_branches/en/south-side.md
+++ b/_branches/en/south-side.md
@@ -12,6 +12,6 @@ As a member of South Side Mutual Aid Solidarity (MAS), we engage in programs to 
 
 ## Get involved
 
-Email us at southside@chicagodsa.org, or message our [Facebook page](https://www.facebook.com/Chicagodsa)
+Email us at [southside@chicagodsa.org](southside@chicagodsa.org), or message our [Facebook page](https://www.facebook.com/Chicagodsa)
 
 {% include comp-button.html text="Find an upcoming event" link="/events" %}

--- a/_branches/en/west-cook.md
+++ b/_branches/en/west-cook.md
@@ -1,0 +1,24 @@
+---
+lang-ref: west-cook
+title: West Cook Branch
+---
+
+## Mission
+
+Our activities have included local electoral work, housing justice, mutual aid, Fair Tax, LaSalle Street Tax, and “Defund the Police” work.
+
+## Get involved
+
+We have monthly general branch membership meetings that we try to schedule on weekend afternoons (historically the second Sunday of the month from 1-3 PM) except when this conflicts with Chapter activities. We also have a Branch Facebook page and google group. The google group is dedicated to DSA related discussions between Branch members.
+
+We encourage all Branch members to join our google group (west-cook-cdsa+unsubscribe@googlegroups.com).
+
+{% include comp-button.html text="Find an upcoming event" link="/events" %}
+
+## Geography
+
+The West Cook Branch covers the western suburbs of Cook County. The branch’s borders are Chicago city limits to the east, Cook County limits to the west, I-55 to the south, and I-90 to the north. Suburbs within the branch include: Bellwood, Berkeley, Berwyn, Broadview, Cicero, Hillside, Forest Park, La Grange, Maywood, Melrose Park, North Riverside, Oak Park and more.
+
+The following zipcodes fall under the West Cook Branch:
+
+60104, 60130, 60131, 60141, 60153, 60154, 60155, 60160, 60162, 60163, 60164, 60165, 60171, 60176, 60301, 60302, 60304, 60305, 60402, 60513, 60525, 60526, 60534, 60546, 60558, 60707, 60804

--- a/_branches/en/west-cook.md
+++ b/_branches/en/west-cook.md
@@ -11,7 +11,9 @@ Our activities have included local electoral work, housing justice, mutual aid, 
 
 We have monthly general branch membership meetings that we try to schedule on weekend afternoons (historically the second Sunday of the month from 1-3 PM) except when this conflicts with Chapter activities. We also have a Branch Facebook page and google group. The google group is dedicated to DSA related discussions between Branch members.
 
-We encourage all Branch members to join our google group (west-cook-cdsa+unsubscribe@googlegroups.com).
+We encourage all Branch members to join our google group:
+
+[west-cook-cdsa+unsubscribe@googlegroups.com](mailto:west-cook-cdsa+unsubscribe@googlegroups.com).
 
 {% include comp-button.html text="Find an upcoming event" link="/events" %}
 

--- a/_config.yml
+++ b/_config.yml
@@ -94,6 +94,10 @@ defaults:
       path: _working-groups/en
     values:
       permalink: working-groups/:title
+  - scope:
+      path: _branches/en
+    values:
+      permalink: branches/:title
 
 # Manage lists of content with collections
 # https://jekyllrb.com/docs/collections/
@@ -112,4 +116,6 @@ collections:
   working-groups:
     output: true
   posts: 
+    output: true
+  branches:
     output: true

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -25,6 +25,10 @@ elements:
           url:
             en: working-groups
       - page:
+          en: Branches
+          url:
+            en: branches
+      - page:
           en: New members
           url:
             en: new-members

--- a/_pages/en/branches.md
+++ b/_pages/en/branches.md
@@ -1,0 +1,15 @@
+---
+lang-ref: branches
+title: Branches
+description: The heart of Chicago DSA is our working groups.
+---
+
+Chicago DSA currently has four territorial branches, defined by zip codes. Each branch has an elected steering committee that plans regular branch meetings. The steering committee members also serve on the chapter’s Executive Committee as Branch Representatives for one-year terms (from June 30th to July 31st). Each branch also has a mutual aid solidarity (MAS) subcommittee that engages members in mutual aid projects. See below for more information about the territorial branches and how to get involved!
+
+You can use the map below to find your branch based on your zip code:
+<iframe src="https://www.google.com/maps/d/embed?mid=1K_oj_p3dVTxHI_t5HaF4Mx1heju03cLa&ll=41.817613978000594%2C-87.65426678372957&z=9" width="640" height="480"></iframe>
+
+
+## Branch Pages
+
+{% include list-tiles.html collection="branches" %}


### PR DESCRIPTION
Link to trello ticket:
https://trello.com/c/ODSYgAGv/63-branches-page

Link to content:
https://docs.google.com/document/d/1mK5YPxIs4gZ35FR5kNyrO8iDVypjgOKjXWr2Wem4g4c/edit#

So I think this should work fine for staging (at least to get some feedback).

The only thing I'm a little unhappy with is tile size:
<img width="944" alt="Screen Shot 2021-05-13 at 8 18 56 PM" src="https://user-images.githubusercontent.com/5639575/118207035-679e0480-b429-11eb-8864-87fd4ab02661.png">

The tiles are pretty big for not having any images... I think the two things we can do are either:
1. Get images from every branch. I can reach out to Alanna for this one since that would be nice to have. South Side and West Cook provided images, so we'd only need from northside branches...
2. Update the Heymarket theme to collapse the tiles a bit if there are no images. I don't see anywhere (in this codebase at least) where tiles are being served without images, so hopefully shouldn't be a tough change... my CSS is terrible though, not sure how to find what is making it happen 😅 . If anyone wants to help I would appreciate it!
